### PR TITLE
Remove non-ASCII limitation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 export default function slash(path) {
 	const isExtendedLengthPath = /^\\\\\?\\/.test(path);
 
-	if (isExtendedLengthPath || hasNonAscii) {
+	if (isExtendedLengthPath) {
 		return path;
 	}
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 export default function slash(path) {
 	const isExtendedLengthPath = /^\\\\\?\\/.test(path);
-	const hasNonAscii = /[^\u0000-\u0080]+/.test(path); // eslint-disable-line no-control-regex
 
 	if (isExtendedLengthPath || hasNonAscii) {
 		return path;

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 > Convert Windows backslash paths to slash paths: `foo\\bar` ➔ `foo/bar`
 
-[Forward-slash paths can be used in Windows](http://superuser.com/a/176395/6877) as long as they're not extended-length paths and don't contain any non-ascii characters.
+[Forward-slash paths can be used in Windows](http://superuser.com/a/176395/6877) as long as they're not extended-length path.
 
 This was created since the `path` methods in Node.js outputs `\\` paths on Windows.
 

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 > Convert Windows backslash paths to slash paths: `foo\\bar` ➔ `foo/bar`
 
-[Forward-slash paths can be used in Windows](http://superuser.com/a/176395/6877) as long as they're not extended-length path.
+[Forward-slash paths can be used in Windows](http://superuser.com/a/176395/6877) as long as they're not extended-length paths.
 
 This was created since the `path` methods in Node.js outputs `\\` paths on Windows.
 

--- a/test.js
+++ b/test.js
@@ -4,14 +4,10 @@ import slash from './index.js';
 test('convert backwards-slash paths to forward slash paths', t => {
 	t.is(slash('c:/aaaa\\bbbb'), 'c:/aaaa/bbbb');
 	t.is(slash('c:\\aaaa\\bbbb'), 'c:/aaaa/bbbb');
+	t.is(slash('c:\\aaaa\\bbbb\\★'), 'c:/aaaa/bbbb/★');
 });
 
 test('not convert extended-length paths', t => {
 	const path = '\\\\?\\c:\\aaaa\\bbbb';
-	t.is(slash(path), path);
-});
-
-test('not convert paths with Unicode', t => {
-	const path = 'c:\\aaaa\\bbbb\\★';
 	t.is(slash(path), path);
 });


### PR DESCRIPTION
Closes #19 (see that issue for more information)

I have been unable to find documentation for the non-ASCII limitation, and anecdotal testing has shown forward slashes to be supported in non-ASCII paths:

<p align="center"><img alt="Screenshot of terminal showing Node.js reading file with non-ASCII path with both forward and backward slashes as seperator" src="https://user-images.githubusercontent.com/4542461/192226162-1ef51af6-d538-4b54-a954-38ddd1c89a0a.png" /></p>

This limitation has further caused issues in projects that rely on this, e.g. https://github.com/facebook/docusaurus/issues/8124, https://github.com/gatsbyjs/gatsby/pull/19600, and https://github.com/SAP/ui5-tooling/issues/469, amongst others.