### PR TITLE
Removes regex from extended length path check

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 export default function slash(path) {
-	const isExtendedLengthPath = /^\\\\\?\\/.test(path);
+	const isExtendedLengthPath = path.startsWith("\\\\?\\");
 
 	if (isExtendedLengthPath) {
 		return path;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 export default function slash(path) {
-	const isExtendedLengthPath = path.startsWith("\\\\?\\");
+	const isExtendedLengthPath = path.startsWith('\\\\?\\');
 
 	if (isExtendedLengthPath) {
 		return path;


### PR DESCRIPTION
The existing method uses regex to check if the first four characters indicate that the path is an extended-length path. This is not as performant as using `startsWith` which checks the first four characters without using a regex.

Using the `benchmark` package, I compared the performance by evaluating the following strings:

``` js
const NORMAL_STRING_WITH_REPLACE = "C:\\test\\path";
const EXTENDED_PATH = "\\\\?\\C:\\test\\path";
const NORMAL_STRING_NO_REPLACE = "C:/test/path";

function slash_original(path) {
	const isExtendedLengthPath = /^\\\\\?\\/.test(path);

	if (isExtendedLengthPath) {
		return path;
	}

	return path.replace(/\\/g, '/');
}

function slash_new(path) {
	const isExtendedLengthPath = path.startsWith("\\\\?\\");

	if (isExtendedLengthPath) {
		return path;
	}

	return path.replace(/\\/g, '/');
}
```

The resulting data backed up the idea for performance improvement:

### NORMAL_STRING_WITH_REPLACE
original x 4,243,922 ops/sec ±0.95% (88 runs sampled)
new x 4,591,650 ops/sec ±0.78% (91 runs sampled)

~8.1% increase in ops/sec

### EXTENDED_PATH
original x 26,703,612 ops/sec ±1.16% (93 runs sampled)
new x 43,472,723 ops/sec ±3.22% (87 runs sampled)

~62% increase in ops/sec

### NORMAL_STRING_NO_REPLACE
original x 10,698,194 ops/sec ±0.82% (92 runs sampled)
new x 12,566,525 ops/sec ±0.80% (94 runs sampled)

~17% increase in ops/sec

Note that these benchmarks were run on my local notebook though repeated multiple times with similar results.